### PR TITLE
[3.5 | Switch] Separate the Audren driver into its own directory

### DIFF
--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -10,6 +10,8 @@ SConscript("windows/SCsub")
 
 # Sounds drivers
 SConscript("alsa/SCsub")
+if env["platform"] == "switch":
+    SConscript("audren/SCsub")
 SConscript("coreaudio/SCsub")
 SConscript("pulseaudio/SCsub")
 if env["platform"] == "windows":

--- a/drivers/audren/SCsub
+++ b/drivers/audren/SCsub
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+
+Import("env")
+
+# Driver source files
+env.add_source_files(env.drivers_sources, "audio_driver_audren.cpp")

--- a/drivers/audren/audio_driver_audren.cpp
+++ b/drivers/audren/audio_driver_audren.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  audio_driver_switch.cpp                                               */
+/*  audio_driver_audren.cpp                                               */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "audio_driver_switch.h"
+#include "audio_driver_audren.h"
 
 #include "core/os/os.h"
 #include "core/project_settings.h"
@@ -45,7 +45,7 @@ static const AudioRendererConfig arConfig = {
 	.num_mix_buffers = 2,
 };
 
-Error AudioDriverSwitch::init_device() {
+Error AudioDriverAudren::init_device() {
 	int latency = GLOBAL_GET("audio/output_latency");
 	mix_rate = GLOBAL_GET("audio/mix_rate");
 	channels = 2;
@@ -98,21 +98,21 @@ Error AudioDriverSwitch::init_device() {
 	return OK;
 }
 
-Error AudioDriverSwitch::init() {
+Error AudioDriverAudren::init() {
 	active = false;
 	thread_exited = false;
 	exit_thread = false;
 
 	Error err = init_device();
 	if (err == OK) {
-		thread.start(AudioDriverSwitch::thread_func, this);
+		thread.start(AudioDriverAudren::thread_func, this);
 	}
 
 	return err;
 }
 
-void AudioDriverSwitch::thread_func(void *p_udata) {
-	AudioDriverSwitch *ad = (AudioDriverSwitch *)p_udata;
+void AudioDriverAudren::thread_func(void *p_udata) {
+	AudioDriverAudren *ad = (AudioDriverAudren *)p_udata;
 
 	svcSetThreadPriority(CUR_THREAD_HANDLE, 0x2B);
 
@@ -168,43 +168,43 @@ void AudioDriverSwitch::thread_func(void *p_udata) {
 	ad->thread_exited = true;
 }
 
-void AudioDriverSwitch::start() {
+void AudioDriverAudren::start() {
 	active = true;
 }
 
-int AudioDriverSwitch::get_mix_rate() const {
+int AudioDriverAudren::get_mix_rate() const {
 	return mix_rate;
 }
 
-AudioDriver::SpeakerMode AudioDriverSwitch::get_speaker_mode() const {
+AudioDriver::SpeakerMode AudioDriverAudren::get_speaker_mode() const {
 	return speaker_mode;
 }
 
-Array AudioDriverSwitch::get_device_list() {
+Array AudioDriverAudren::get_device_list() {
 	Array list;
 	list.push_back("Default");
 	return list;
 }
 
-String AudioDriverSwitch::get_device() {
+String AudioDriverAudren::get_device() {
 	return device_name;
 }
 
-void AudioDriverSwitch::set_device(String device) {
+void AudioDriverAudren::set_device(String device) {
 	lock();
 	new_device = device;
 	unlock();
 }
 
-void AudioDriverSwitch::lock() {
+void AudioDriverAudren::lock() {
 	mutex.lock();
 }
 
-void AudioDriverSwitch::unlock() {
+void AudioDriverAudren::unlock() {
 	mutex.unlock();
 }
 
-void AudioDriverSwitch::finish() {
+void AudioDriverAudren::finish() {
 	exit_thread = true;
 	thread.wait_to_finish();
 
@@ -212,10 +212,10 @@ void AudioDriverSwitch::finish() {
 	audrenExit();
 }
 
-AudioDriverSwitch::AudioDriverSwitch() :
+AudioDriverAudren::AudioDriverAudren() :
 		device_name("Default"),
 		new_device("Default") {
 }
 
-AudioDriverSwitch::~AudioDriverSwitch() {
+AudioDriverAudren::~AudioDriverAudren() {
 }

--- a/drivers/audren/audio_driver_audren.h
+++ b/drivers/audren/audio_driver_audren.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  audio_driver_switch.h                                                 */
+/*  audio_driver_audren.h                                                 */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,13 +28,17 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#pragma once
+#ifndef AUDIO_DRIVER_AUDREN_H
+#define AUDIO_DRIVER_AUDREN_H
+
 #include "servers/audio_server.h"
 #include "switch_wrapper.h"
 
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
 
-class AudioDriverSwitch : public AudioDriver {
+class AudioDriverAudren : public AudioDriver {
 	Thread thread;
 	Mutex mutex;
 
@@ -79,6 +83,8 @@ public:
 	virtual void unlock();
 	virtual void finish();
 
-	AudioDriverSwitch();
-	~AudioDriverSwitch();
+	AudioDriverAudren();
+	~AudioDriverAudren();
 };
+
+#endif // !AUDIO_DRIVER_AUDREN_H

--- a/platform/switch/SCsub
+++ b/platform/switch/SCsub
@@ -9,7 +9,6 @@ files = [
     "os_switch.cpp",
     "power_switch.cpp",
     "joypad_switch.cpp",
-    "audio_driver_switch.cpp",
     "context_gl_switch_egl.cpp",
 ]
 

--- a/platform/switch/os_switch.cpp
+++ b/platform/switch/os_switch.cpp
@@ -556,7 +556,7 @@ OS_Switch::OS_Switch() {
 	input = nullptr;
 	power_manager = nullptr;
 	gl_context = nullptr;
-	AudioDriverManager::add_driver(&driver_switch);
+	AudioDriverManager::add_driver(&driver_audren);
 
 	swkbdInlineCreate(&inline_keyboard);
 }

--- a/platform/switch/os_switch.h
+++ b/platform/switch/os_switch.h
@@ -28,10 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "audio_driver_switch.h"
 #include "context_gl_switch_egl.h"
 #include "core/os/input.h"
 #include "core/os/os.h"
+#include "drivers/audren/audio_driver_audren.h"
 #include "joypad_switch.h"
 #include "main/input_default.h"
 #include "power_switch.h"
@@ -46,7 +46,7 @@ class OS_Switch : public OS {
 	PowerSwitch *power_manager;
 	ContextGLSwitchEGL *gl_context;
 	JoypadSwitch *joypad;
-	AudioDriverSwitch driver_switch;
+	AudioDriverAudren driver_audren;
 	String switch_execpath;
 
 	SwkbdInline inline_keyboard;


### PR DESCRIPTION
- Separated the Switch audio driver into its own directory, behind a pre-processor flag.
  There may be other audio drivers provided by the LibNX in the future.