### PR TITLE
Add get and set functions for joypad motion sensors

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -86,10 +86,18 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_accelerometer"), &Input::get_accelerometer);
 	ClassDB::bind_method(D_METHOD("get_magnetometer"), &Input::get_magnetometer);
 	ClassDB::bind_method(D_METHOD("get_gyroscope"), &Input::get_gyroscope);
+	ClassDB::bind_method(D_METHOD("get_joy_gravity", "device"), &Input::get_joy_gravity);
+	ClassDB::bind_method(D_METHOD("get_joy_accelerometer", "device"), &Input::get_joy_accelerometer);
+	ClassDB::bind_method(D_METHOD("get_joy_magnetometer", "device"), &Input::get_joy_magnetometer);
+	ClassDB::bind_method(D_METHOD("get_joy_gyroscope", "device"), &Input::get_joy_gyroscope);
 	ClassDB::bind_method(D_METHOD("set_gravity", "value"), &Input::set_gravity);
 	ClassDB::bind_method(D_METHOD("set_accelerometer", "value"), &Input::set_accelerometer);
 	ClassDB::bind_method(D_METHOD("set_magnetometer", "value"), &Input::set_magnetometer);
 	ClassDB::bind_method(D_METHOD("set_gyroscope", "value"), &Input::set_gyroscope);
+	ClassDB::bind_method(D_METHOD("set_joy_gravity", "device", "value"), &Input::set_joy_gravity);
+	ClassDB::bind_method(D_METHOD("set_joy_accelerometer", "device", "value"), &Input::set_joy_accelerometer);
+	ClassDB::bind_method(D_METHOD("set_joy_magnetometer", "device", "value"), &Input::set_joy_magnetometer);
+	ClassDB::bind_method(D_METHOD("set_joy_gyroscope", "device", "value"), &Input::set_joy_gyroscope);
 	//ClassDB::bind_method(D_METHOD("get_mouse_position"),&Input::get_mouse_position); - this is not the function you want
 	ClassDB::bind_method(D_METHOD("get_last_mouse_speed"), &Input::get_last_mouse_speed);
 	ClassDB::bind_method(D_METHOD("get_mouse_button_mask"), &Input::get_mouse_button_mask);

--- a/core/os/input.h
+++ b/core/os/input.h
@@ -117,10 +117,18 @@ public:
 	virtual Vector3 get_accelerometer() const = 0;
 	virtual Vector3 get_magnetometer() const = 0;
 	virtual Vector3 get_gyroscope() const = 0;
+	virtual Vector3 get_joy_gravity(int p_device) const = 0;
+	virtual Vector3 get_joy_accelerometer(int p_device) const = 0;
+	virtual Vector3 get_joy_magnetometer(int p_device) const = 0;
+	virtual Vector3 get_joy_gyroscope(int p_device) const = 0;
 	virtual void set_gravity(const Vector3 &p_gravity) = 0;
 	virtual void set_accelerometer(const Vector3 &p_accel) = 0;
 	virtual void set_magnetometer(const Vector3 &p_magnetometer) = 0;
 	virtual void set_gyroscope(const Vector3 &p_gyroscope) = 0;
+	virtual void set_joy_gravity(int p_device, const Vector3 &p_gravity) = 0;
+	virtual void set_joy_accelerometer(int p_device, const Vector3 &p_accel) = 0;
+	virtual void set_joy_magnetometer(int p_device, const Vector3 &p_magnetometer) = 0;
+	virtual void set_joy_gyroscope(int p_device, const Vector3 &p_gyroscope) = 0;
 
 	virtual void action_press(const StringName &p_action, float p_strength = 1.f) = 0;
 	virtual void action_release(const StringName &p_action) = 0;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -105,6 +105,13 @@
 				[b]Note:[/b] This method only works on Android and iOS. On other platforms, it always returns [constant Vector3.ZERO].
 			</description>
 		</method>
+		<method name="get_joy_accelerometer" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="device" type="int" />
+			<description>
+				Returns the acceleration of the controller's accelerometer sensor, if the controller has one. Otherwise, the method returns [constant Vector3.ZERO].
+			</description>
+		</method>
 		<method name="get_joy_axis" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="device" type="int" />
@@ -141,11 +148,32 @@
 				Receives a gamepad button from [enum JoystickList] and returns its equivalent name as a string.
 			</description>
 		</method>
+		<method name="get_joy_gravity" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="device" type="int" />
+			<description>
+				Returns the gravity of the controller's accelerometer sensor, if the controller has one. Otherwise, the method returns [constant Vector3.ZERO].
+			</description>
+		</method>
 		<method name="get_joy_guid" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="device" type="int" />
 			<description>
 				Returns a SDL2-compatible device GUID on platforms that use gamepad remapping, e.g. [code]030000004c050000c405000000010000[/code]. Returns [code]"Default Gamepad"[/code] otherwise. Godot uses the [url=https://github.com/gabomdq/SDL_GameControllerDB]SDL2 game controller database[/url] to determine gamepad names and mappings based on this GUID.
+			</description>
+		</method>
+		<method name="get_joy_gyroscope" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="device" type="int" />
+			<description>
+				Returns the rotation rate in rad/s around a controller's X, Y, and Z axes of the gyroscope sensor, if the controller has one. Otherwise, the method returns [constant Vector3.ZERO].
+			</description>
+		</method>
+		<method name="get_joy_magnetometer" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="device" type="int" />
+			<description>
+				Returns the magnetic field strength in micro-Tesla for all axes of the controller's magnetometer sensor, if the controller has one. Otherwise, the method returns [constant Vector3.ZERO].
 			</description>
 		</method>
 		<method name="get_joy_name">
@@ -346,15 +374,53 @@
 			<return type="void" />
 			<argument index="0" name="value" type="Vector3" />
 			<description>
-				Sets the value of the rotation rate of the gyroscope sensor. Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
+				Sets the value of the rotation rate of the device's gyroscope sensor.
+				Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
+			</description>
+		</method>
+		<method name="set_joy_accelerometer">
+			<return type="void" />
+			<argument index="0" name="device" type="int" />
+			<argument index="1" name="value" type="Vector3" />
+			<description>
+				Sets the acceleration value of the controller's accelerometer sensor.
+				Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
+			</description>
+		</method>
+		<method name="set_joy_gravity">
+			<return type="void" />
+			<argument index="0" name="device" type="int" />
+			<argument index="1" name="value" type="Vector3" />
+			<description>
+				Sets the gravity value of the controller's accelerometer sensor.
+				Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
+			</description>
+		</method>
+		<method name="set_joy_gyroscope">
+			<return type="void" />
+			<argument index="0" name="device" type="int" />
+			<argument index="1" name="value" type="Vector3" />
+			<description>
+				Sets the value of the rotation rate of the controller's gyroscope sensor.
+				Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
+			</description>
+		</method>
+		<method name="set_joy_magnetometer">
+			<return type="void" />
+			<argument index="0" name="device" type="int" />
+			<argument index="1" name="value" type="Vector3" />
+			<description>
+				Sets the value of the magnetic field of the controller's magnetometer sensor.
+				Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
 			</description>
 		</method>
 		<method name="set_magnetometer">
 			<return type="void" />
 			<argument index="0" name="value" type="Vector3" />
 			<description>
-				Sets the value of the magnetic field of the magnetometer sensor. Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
+				Sets the value of the magnetic field of the device's magnetometer sensor.
+				Can be used for debugging on devices without a hardware sensor, for example in an editor on a PC.
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
 			</description>
 		</method>

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -205,6 +205,26 @@ float InputDefault::get_joy_axis(int p_device, int p_axis) const {
 	}
 }
 
+Vector3 InputDefault::get_joy_gravity(int p_device) const {
+	_THREAD_SAFE_METHOD_
+	return gravity;
+}
+
+Vector3 InputDefault::get_joy_accelerometer(int p_device) const {
+	_THREAD_SAFE_METHOD_
+	return accelerometer;
+}
+
+Vector3 InputDefault::get_joy_magnetometer(int p_device) const {
+	_THREAD_SAFE_METHOD_
+	return magnetometer;
+}
+
+Vector3 InputDefault::get_joy_gyroscope(int p_device) const {
+	_THREAD_SAFE_METHOD_
+	return gyroscope;
+}
+
 String InputDefault::get_joy_name(int p_idx) {
 	_THREAD_SAFE_METHOD_
 	return joy_names[p_idx].name;
@@ -497,6 +517,30 @@ void InputDefault::set_joy_axis(int p_device, int p_axis, float p_value) {
 	_THREAD_SAFE_METHOD_
 	int c = _combine_device(p_axis, p_device);
 	_joy_axis[c] = p_value;
+}
+
+void InputDefault::set_joy_gravity(int p_device, const Vector3 &p_gravity) {
+	_THREAD_SAFE_METHOD_
+
+	gravity = p_gravity;
+}
+
+void InputDefault::set_joy_accelerometer(int p_device, const Vector3 &p_accel) {
+	_THREAD_SAFE_METHOD_
+
+	accelerometer = p_accel;
+}
+
+void InputDefault::set_joy_magnetometer(int p_device, const Vector3 &p_magnetometer) {
+	_THREAD_SAFE_METHOD_
+
+	magnetometer = p_magnetometer;
+}
+
+void InputDefault::set_joy_gyroscope(int p_device, const Vector3 &p_gyroscope) {
+	_THREAD_SAFE_METHOD_
+
+	gyroscope = p_gyroscope;
 }
 
 void InputDefault::start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration) {

--- a/main/input_default.h
+++ b/main/input_default.h
@@ -226,6 +226,10 @@ public:
 	virtual float get_action_raw_strength(const StringName &p_action, bool p_exact = false) const;
 
 	virtual float get_joy_axis(int p_device, int p_axis) const;
+	virtual Vector3 get_joy_gravity(int p_device) const;
+	virtual Vector3 get_joy_accelerometer(int p_device) const;
+	virtual Vector3 get_joy_magnetometer(int p_device) const;
+	virtual Vector3 get_joy_gyroscope(int p_device) const;
 	String get_joy_name(int p_idx);
 	virtual Array get_connected_joypads();
 	virtual Vector2 get_joy_vibration_strength(int p_device);
@@ -252,6 +256,10 @@ public:
 	virtual void set_magnetometer(const Vector3 &p_magnetometer);
 	virtual void set_gyroscope(const Vector3 &p_gyroscope);
 	void set_joy_axis(int p_device, int p_axis, float p_value);
+	virtual void set_joy_gravity(int p_device, const Vector3 &p_gravity);
+	virtual void set_joy_accelerometer(int p_device, const Vector3 &p_accel);
+	virtual void set_joy_magnetometer(int p_device, const Vector3 &p_magnetometer);
+	virtual void set_joy_gyroscope(int p_device, const Vector3 &p_gyroscope);
 
 	virtual void start_joy_vibration(int p_device, float p_weak_magnitude, float p_strong_magnitude, float p_duration = 0);
 	virtual void stop_joy_vibration(int p_device);


### PR DESCRIPTION
For all existing platforms, these do exactly the same thing as the device motion sensor methods.

But these will be useful for platforms that expose each controller's motion sensor data.