### PR TITLE
Disable homebrew exporters on Mono editors

### DIFF
--- a/platform/switch/export/export.h
+++ b/platform/switch/export/export.h
@@ -28,6 +28,11 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifndef SWITCH_EXPORT_H
+#define SWITCH_EXPORT_H
+
+#ifndef MODULE_MONO_ENABLED
+
 #include "thirdparty/libnx/nacp.h"
 #include "thirdparty/libnx/nro.h"
 #include <cstring>
@@ -38,3 +43,7 @@ unsigned char *read_bytes(const char *fn, size_t off, size_t len);
 size_t write_bytes(const char *fn, size_t off, size_t len, const unsigned char *data);
 
 void register_switch_exporter();
+
+#endif // !MODULE_MONO_ENABLED
+
+#endif // !SWITCH_EXPORT_H

--- a/platform/vita/export/export.h
+++ b/platform/vita/export/export.h
@@ -31,6 +31,8 @@
 #ifndef VITA_EXPORT_H
 #define VITA_EXPORT_H
 
+#ifndef MODULE_MONO_ENABLED
+
 #include "core/io/file_access_memory.h"
 #include "editor/editor_export.h"
 #include "editor/editor_node.h"
@@ -49,4 +51,6 @@ typedef struct ParamSFOStruct {
 int mksfoex(ParamSFOStruct *sfo, String outDir);
 void register_vita_exporter();
 
-#endif // VITA_EXPORT_H
+#endif // !MODULE_MONO_ENABLED
+
+#endif // !VITA_EXPORT_H


### PR DESCRIPTION
It should not be implied that Switch and Vita export are supported by the Mono version of the editor, as Switch and Vita do not support Mono themselves.