### PR TITLE
[Switch] Fix OS_Switch::show_virtual_keyboard

### DIFF
--- a/platform/switch/os_switch.cpp
+++ b/platform/switch/os_switch.cpp
@@ -459,7 +459,7 @@ void OS_Switch::run() {
 		joypad->process();
 		input->flush_buffered_events();
         
-        swkbdInlineUpdate(&inline_keyboard, NULL);
+		swkbdInlineUpdate(&inline_keyboard, NULL);
 
 		if (Main::iteration())
 			break;

--- a/platform/switch/os_switch.cpp
+++ b/platform/switch/os_switch.cpp
@@ -456,10 +456,9 @@ void OS_Switch::run() {
 			}
 		}
 
+        swkbdInlineUpdate(&inline_keyboard, NULL);
 		joypad->process();
 		input->flush_buffered_events();
-
-		swkbdInlineUpdate(&inline_keyboard, NULL);
 
 		if (Main::iteration())
 			break;
@@ -478,15 +477,15 @@ bool OS_Switch::has_virtual_keyboard() const {
 }
 
 int OS_Switch::get_virtual_keyboard_height() const {
-	// todo: actually figure this out
 	if (!g_swkbd_open) {
 		return 0;
 	}
-	return 300;
+	return 400;
 }
 
-void OS_Switch::show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect, int p_max_input_length) {
-	if (!g_swkbd_open) {
+void OS_Switch::show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect, bool p_multiline, int p_max_input_length, int p_cursor_start, int p_cursor_end) {
+	printf("Showing kbd!\n");
+    if (!g_swkbd_open) {
 		g_swkbd_open = true;
 
 		SwkbdAppearArg appear_arg;
@@ -501,7 +500,6 @@ void OS_Switch::show_virtual_keyboard(const String &p_existing_text, const Rect2
 }
 
 void OS_Switch::hide_virtual_keyboard() {
-	printf("Hiding kbd!\n");
 	g_swkbd_open = false;
 	swkbdInlineDisappear(&inline_keyboard);
 }

--- a/platform/switch/os_switch.cpp
+++ b/platform/switch/os_switch.cpp
@@ -456,9 +456,10 @@ void OS_Switch::run() {
 			}
 		}
 
-        swkbdInlineUpdate(&inline_keyboard, NULL);
 		joypad->process();
 		input->flush_buffered_events();
+        
+        swkbdInlineUpdate(&inline_keyboard, NULL);
 
 		if (Main::iteration())
 			break;

--- a/platform/switch/os_switch.cpp
+++ b/platform/switch/os_switch.cpp
@@ -485,7 +485,7 @@ int OS_Switch::get_virtual_keyboard_height() const {
 }
 
 void OS_Switch::show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect, bool p_multiline, int p_max_input_length, int p_cursor_start, int p_cursor_end) {
-    if (!g_swkbd_open) {
+	if (!g_swkbd_open) {
 		g_swkbd_open = true;
 
 		SwkbdAppearArg appear_arg;

--- a/platform/switch/os_switch.cpp
+++ b/platform/switch/os_switch.cpp
@@ -458,7 +458,7 @@ void OS_Switch::run() {
 
 		joypad->process();
 		input->flush_buffered_events();
-        
+
 		swkbdInlineUpdate(&inline_keyboard, NULL);
 
 		if (Main::iteration())
@@ -485,7 +485,6 @@ int OS_Switch::get_virtual_keyboard_height() const {
 }
 
 void OS_Switch::show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect, bool p_multiline, int p_max_input_length, int p_cursor_start, int p_cursor_end) {
-	printf("Showing kbd!\n");
     if (!g_swkbd_open) {
 		g_swkbd_open = true;
 

--- a/platform/switch/os_switch.h
+++ b/platform/switch/os_switch.h
@@ -108,7 +108,7 @@ public:
 	virtual bool has_touchscreen_ui_hint() const;
 
 	virtual bool has_virtual_keyboard() const;
-	virtual void show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect = Rect2(), int p_max_input_length = -1);
+	virtual void show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect = Rect2(), bool p_multiline = false, int p_max_input_length = -1, int p_cursor_start = -1, int p_cursor_end = -1);
 	virtual void hide_virtual_keyboard();
 	virtual int get_virtual_keyboard_height() const;
 


### PR DESCRIPTION
Implementation of OS_Switch::show_virtual_keyboard is wrong, arguments list doesn't match the format os.show_virtual_keyboard expects:

os.h
`virtual void show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect = Rect2(), bool p_multiline = false, int p_max_input_length = -1, int p_cursor_start = -1, int p_cursor_end = -1);`

os_switch.h:
`virtual void show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect = Rect2(), int p_max_input_length = -1);`

This is why the show_virtual_keyboard method never executes any of the code within, despite everything else about the inline software keyboard from libnx otherwise largely working.